### PR TITLE
expect の廃止  & apt GUI選択の抑制

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,6 @@ sudo apt-get install -y mysql-server libmysqld-dev
 mysqladmin -p'root' password '' -u root
 sudo apt-get install -y ruby ruby-dev
 sudo apt-get install -y libmagickwand-dev imagemagick
-sudo apt-get install -y expect
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 561F9B9CAC40B2F7
 sudo apt-get install -y apt-transport-https ca-certificates
 sudo apt-get install -y nginx
@@ -35,14 +34,7 @@ sudo -u unicorn sh -c $SCRIPT_DIR/unicorn-tasks.sh
 
 cd /home/unicorn/redmine/
 sudo RAILS_ENV=production bundle exec rake db:migrate
-expect -c '
-spawn sudo RAILS_ENV=production bundle exec rake redmine:load_default_data
-
-set timeout 30
-expect "Select language:*"
-send "ja\n"
-interact
-'
+sudo RAILS_ENV=production REDMINE_LANG=ja bundle exec rake redmine:load_default_data
 
 sudo chmod 777 tmp
 sudo chmod 777 db

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR=$(cd $(dirname $0);pwd)
 
 #general #{{{1
-
+echo "set grub-pc/install_devices /dev/sda" | sudo debconf-communicate
 sudo apt-get update
 sudo apt-get upgrade -y
 sudo apt-get install -y git openssh-server language-pack-ja

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -81,17 +81,7 @@ sudo systemctl restart postfix
 # sudo systemctl restart postfix
 
 # ssh-keygen #{{{1
-expect -c '
-set timeout 10
-spawn ssh-keygen -t rsa
-expect -re "Enter file in which to save the key\ (.\*\):"
-send "\n"
-expect "Enter passphrase \(empty for no passphrase\):"
-send "\n"
-expect "Enter same passphrase again:"
-send "\n"
-interact
-'
+ssh-keygen -t rsa -b 4096 -f $HOME/.ssh/id_rsa  -N ""
 
 # gitolite #{{{1
 sudo useradd -m -U -r -s /bin/bash -d /srv/git git

--- a/git-tasks.sh
+++ b/git-tasks.sh
@@ -3,17 +3,7 @@
 HOME=/srv/git
 cd $HOME
 
-expect -c '
-set timeout 10
-spawn ssh-keygen -t rsa
-expect -re "Enter file in which to save the key\ (.\*\):"
-send "\n"
-expect "Enter passphrase \(empty for no passphrase\):"
-send "\n"
-expect "Enter same passphrase again:"
-send "\n"
-interact
-'
+ssh-keygen -t rsa -b 4096 -f $HOME/.ssh/id_rsa  -N ""
 touch .ssh/authorized_keys
 
 git clone http://github.com/sitaramc/gitolite.git


### PR DESCRIPTION
- expect の廃止
  - ssh-keygen の一行化
  - Rake redmine:load_default_data の環境変数による言語指定
- apt-get upgrade 時に GUI選択になることを防ぐ  
  grub 設定が必要らしく, /dev/sda にbootパーティションがあることを指定している
